### PR TITLE
Makefile.mingw: Fix some syntax problems

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -100,8 +100,7 @@ all-before:
 	if not exist $(OUTDIR) mkdir $(OUTDIR)
 
 nsis-sdk:
-	REM ----- NSIS SDK ------------------------------------------------------------
-	call py -3 _get_nsis_sdk.py
+	python3 _get_nsis_sdk.py
 
 # Link
 $(_BIN): $(_OBJ)


### PR DESCRIPTION
In Makefiles, REM and call aren't valid syntax (though they are for batch files!)

To work around this, let's just run "python3 _get_nsis_sdk.py" instead. 😃